### PR TITLE
Added gzip compression

### DIFF
--- a/src/presentation/API/Program.cs
+++ b/src/presentation/API/Program.cs
@@ -14,6 +14,7 @@ builder.Services.AddControllers();
 
 var app = builder.Build();
 
+app.UseResponseCompression();
 app.UseSerilogRequestLogging();
 app.UseHttpsRedirection();
 app.UseRouting();

--- a/src/presentation/API/Registrations/ResponseCompression/ResponseCompressingExtensions.cs
+++ b/src/presentation/API/Registrations/ResponseCompression/ResponseCompressingExtensions.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.AspNetCore.ResponseCompression;
+using System.IO.Compression;
+
+namespace API.Registrations.ResponseCompression
+{
+    public static class ResponseCompressingExtensions
+    {
+        public static void ConfigureResponseCompression(this IServiceCollection services)
+        {
+            services.Configure<GzipCompressionProviderOptions>(opt =>
+            {
+                opt.Level = CompressionLevel.Fastest;
+            });
+
+            services.AddResponseCompression(options =>
+            {
+                options.EnableForHttps = true;
+                options.Providers.Add<GzipCompressionProvider>(); 
+            });         
+        }
+    }
+}

--- a/src/presentation/API/Registrations/ResponseCompression/ResponseCompressingExtensions.cs
+++ b/src/presentation/API/Registrations/ResponseCompression/ResponseCompressingExtensions.cs
@@ -1,8 +1,8 @@
-﻿using Microsoft.AspNetCore.ResponseCompression;
-using System.IO.Compression;
-
-namespace API.Registrations.ResponseCompression
+﻿namespace API.Registrations.ResponseCompression
 {
+    using Microsoft.AspNetCore.ResponseCompression;
+    using System.IO.Compression;
+
     public static class ResponseCompressingExtensions
     {
         public static void ConfigureResponseCompression(this IServiceCollection services)
@@ -15,8 +15,8 @@ namespace API.Registrations.ResponseCompression
             services.AddResponseCompression(options =>
             {
                 options.EnableForHttps = true;
-                options.Providers.Add<GzipCompressionProvider>(); 
-            });         
+                options.Providers.Add<GzipCompressionProvider>();
+            });
         }
     }
 }

--- a/src/presentation/API/Registrations/ServiceRegistration.cs
+++ b/src/presentation/API/Registrations/ServiceRegistration.cs
@@ -1,6 +1,7 @@
 ﻿namespace API.Registrations
 {
     using API.Registrations.HealthChecks;
+    using API.Registrations.ResponseCompression;
     using ApplicationLayer;
     using PersistenceLayer;
     using Swagger;
@@ -10,6 +11,7 @@
     {
         public static IServiceCollection AddServices(this IServiceCollection services, IConfiguration configuration)
         {
+            services.ConfigureResponseCompression();
             services.Configure<RouteOptions>(options => options.LowercaseUrls = true);
             services.RegisterDatabase(configuration);
             services.AddApplicationServices();
@@ -19,7 +21,7 @@
             {
                 o.IncludeXmlComments(Path.Combine(AppContext.BaseDirectory, $"{Assembly.GetExecutingAssembly().GetName().Name}.xml"));
             });
-            services.AddCustomHealthChecks(configuration);
+            services.AddCustomHealthChecks(configuration);         
 
             return services;
         }


### PR DESCRIPTION
**Work performed**
Added gzip compression middleware to reduce size of response

**Tests performed**
Called api endpoints via swagger UI and checked network in developer tools.
Products response without compression has 30.07 kB and with compression it was only 2.5 kB


fixes #55 