### PR TITLE
Added cookie with running order number and its usage

### DIFF
--- a/others/RadesSoft.HateoasMaker/Extensions/HateoasResponseExtensions.cs
+++ b/others/RadesSoft.HateoasMaker/Extensions/HateoasResponseExtensions.cs
@@ -1,0 +1,55 @@
+﻿using RadesSoft.HateoasMaker.Models;
+
+namespace RadesSoft.HateoasMaker.Extensions
+{
+	public static class HateoasResponseExtensions
+	{
+		public static void ReplaceInLink(this HateoasResponse res, string oldVal, string newVal)
+		{
+			if (res.Curl is not null)
+			{
+				res.Curl.ReplaceInHref(oldVal, newVal);
+			}
+		}
+
+		public static void ReplaceInLink(this HateoasResponse res, string oldVal, string newVal, string oldVal2, string newVal2)
+		{
+			if (res.Curl is not null)
+			{
+				res.Curl.ReplaceInHref(oldVal, newVal, oldVal2, newVal2);
+			}
+		}
+
+		public static void ReplaceInLink(this HateoasResponse res, string oldVal, string newVal, string oldVal2, string newVal2, string oldVal3, string newVal3)
+		{
+			if (res.Curl is not null)
+			{
+				res.Curl.ReplaceInHref(oldVal, newVal, oldVal2, newVal2, oldVal3, newVal3);
+			}
+		}
+
+		public static void ReplaceInLink(this HateoasResponse res, string oldVal, string newVal, string oldVal2, string newVal2, string oldVal3, string newVal3, string oldVal4, string newVal4)
+		{
+			if (res.Curl is not null)
+			{
+				res.Curl.ReplaceInHref(oldVal, newVal, oldVal2, newVal2, oldVal3, newVal3, oldVal4, newVal4);
+			}
+		}
+
+		public static void ReplaceInLink(this HateoasResponse res, string oldVal, string newVal, string oldVal2, string newVal2, string oldVal3, string newVal3, string oldVal4, string newVal4, string oldVal5, string newVal5)
+		{
+			if (res.Curl is not null)
+			{
+				res.Curl.ReplaceInHref(oldVal, newVal, oldVal2, newVal2, oldVal3, newVal3, oldVal4, newVal4, oldVal5, newVal5);
+			}
+		}
+
+		public static void ReplaceInLink(this HateoasResponse res, Dictionary<string, string> oldNewPairs)
+		{
+			if (res.Curl is not null)
+			{
+				res.Curl.ReplaceInHref(oldNewPairs);
+			}
+		}
+	}
+}

--- a/others/RadesSoft.HateoasMaker/Extensions/HateoasResponseExtensions.cs
+++ b/others/RadesSoft.HateoasMaker/Extensions/HateoasResponseExtensions.cs
@@ -28,22 +28,6 @@ namespace RadesSoft.HateoasMaker.Extensions
 			}
 		}
 
-		public static void ReplaceInLink(this HateoasResponse res, string oldVal, string newVal, string oldVal2, string newVal2, string oldVal3, string newVal3, string oldVal4, string newVal4)
-		{
-			if (res.Curl is not null)
-			{
-				res.Curl.ReplaceInHref(oldVal, newVal, oldVal2, newVal2, oldVal3, newVal3, oldVal4, newVal4);
-			}
-		}
-
-		public static void ReplaceInLink(this HateoasResponse res, string oldVal, string newVal, string oldVal2, string newVal2, string oldVal3, string newVal3, string oldVal4, string newVal4, string oldVal5, string newVal5)
-		{
-			if (res.Curl is not null)
-			{
-				res.Curl.ReplaceInHref(oldVal, newVal, oldVal2, newVal2, oldVal3, newVal3, oldVal4, newVal4, oldVal5, newVal5);
-			}
-		}
-
 		public static void ReplaceInLink(this HateoasResponse res, Dictionary<string, string> oldNewPairs)
 		{
 			if (res.Curl is not null)

--- a/others/RadesSoft.HateoasMaker/Models/HateoasResponseBody.cs
+++ b/others/RadesSoft.HateoasMaker/Models/HateoasResponseBody.cs
@@ -2,7 +2,7 @@
 {
 	public class HateoasResponseBody
 	{
-		public string Href { get; private set; }
+		public string Href { get; set; }
 		public string Rel { get; set; }
 		public string Method { get; private set; }
 		internal HateoasResponseBody(string href, string rel, string method)
@@ -10,6 +10,39 @@
 			Href = href;
 			Rel = rel;
 			Method = method;
+		}
+
+		internal void ReplaceInHref(string oldVal, string newVal)
+		{
+			Href = Href.Replace(oldVal, newVal);
+		}
+
+		internal void ReplaceInHref(string oldVal, string newVal, string oldVal2, string newVal2)
+		{
+			Href = Href.Replace(oldVal, newVal).Replace(oldVal2, newVal2);
+		}
+
+		internal void ReplaceInHref(string oldVal, string newVal, string oldVal2, string newVal2, string oldVal3, string newVal3)
+		{
+			Href = Href.Replace(oldVal, newVal).Replace(oldVal2, newVal2).Replace(oldVal3, newVal3);
+		}
+
+		internal void ReplaceInHref(string oldVal, string newVal, string oldVal2, string newVal2, string oldVal3, string newVal3, string oldVal4, string newVal4)
+		{
+			Href = Href.Replace(oldVal, newVal).Replace(oldVal2, newVal2).Replace(oldVal3, newVal3).Replace(oldVal4, newVal4);
+		}
+
+		internal void ReplaceInHref(string oldVal, string newVal, string oldVal2, string newVal2, string oldVal3, string newVal3, string oldVal4, string newVal4, string oldVal5, string newVal5)
+		{
+			Href = Href.Replace(oldVal, newVal).Replace(oldVal2, newVal2).Replace(oldVal3, newVal3).Replace(oldVal4, newVal4).Replace(oldVal5, newVal5);
+		}
+
+		internal void ReplaceInHref(Dictionary<string, string> keyValuePairs)
+		{
+			foreach (KeyValuePair<string, string> pair in keyValuePairs)
+			{
+				Href = Href.Replace(pair.Key, pair.Value);
+			}
 		}
 	}
 }

--- a/others/RadesSoft.HateoasMaker/Models/HateoasResponseBody.cs
+++ b/others/RadesSoft.HateoasMaker/Models/HateoasResponseBody.cs
@@ -27,16 +27,6 @@
 			Href = Href.Replace(oldVal, newVal).Replace(oldVal2, newVal2).Replace(oldVal3, newVal3);
 		}
 
-		internal void ReplaceInHref(string oldVal, string newVal, string oldVal2, string newVal2, string oldVal3, string newVal3, string oldVal4, string newVal4)
-		{
-			Href = Href.Replace(oldVal, newVal).Replace(oldVal2, newVal2).Replace(oldVal3, newVal3).Replace(oldVal4, newVal4);
-		}
-
-		internal void ReplaceInHref(string oldVal, string newVal, string oldVal2, string newVal2, string oldVal3, string newVal3, string oldVal4, string newVal4, string oldVal5, string newVal5)
-		{
-			Href = Href.Replace(oldVal, newVal).Replace(oldVal2, newVal2).Replace(oldVal3, newVal3).Replace(oldVal4, newVal4).Replace(oldVal5, newVal5);
-		}
-
 		internal void ReplaceInHref(Dictionary<string, string> keyValuePairs)
 		{
 			foreach (KeyValuePair<string, string> pair in keyValuePairs)

--- a/src/core/ApplicationLayer/Requests/Orders/Commands/Put/OrdersPutRequest.cs
+++ b/src/core/ApplicationLayer/Requests/Orders/Commands/Put/OrdersPutRequest.cs
@@ -42,10 +42,12 @@
 				try
 				{
 					var status = await _dbContext.OrderStatuses.FirstAsync(x => x.Id == OrderStatuses.New, cancellationToken);
+					var user = await _dbContext.Users.FirstAsync(x => x.Id == request.UserId);
+
 					_dbContext.Orders.Add(new OrderEntity()
 					{
 						OrderCode = code,
-						UserId = request.UserId,
+						User = user,
 						Total = 0,
 						Status = status!
 					});

--- a/src/core/ApplicationLayer/Requests/Orders/Commands/Put/OrdersPutRequest.cs
+++ b/src/core/ApplicationLayer/Requests/Orders/Commands/Put/OrdersPutRequest.cs
@@ -42,7 +42,7 @@
 				try
 				{
 					var status = await _dbContext.OrderStatuses.FirstAsync(x => x.Id == OrderStatuses.New, cancellationToken);
-					var user = await _dbContext.Users.FirstAsync(x => x.Id == request.UserId);
+					var user = await _dbContext.Users.FirstAsync(x => x.Id == request.UserId, cancellationToken);
 
 					_dbContext.Orders.Add(new OrderEntity()
 					{

--- a/src/core/ApplicationLayer/Requests/Orders/Queries/OrdersGetByUserRequest.cs
+++ b/src/core/ApplicationLayer/Requests/Orders/Queries/OrdersGetByUserRequest.cs
@@ -38,7 +38,7 @@
 					var response = new OrdersGetResponse
 					{
 						OrderCode = order.OrderCode,
-						OrderStatus = order.Status.Name,
+						OrderStatus = order.Status.Id,
 						Total = order.Total,
 					};
 

--- a/src/core/ApplicationLayer/Requests/Orders/Queries/OrdersGetResponse.cs
+++ b/src/core/ApplicationLayer/Requests/Orders/Queries/OrdersGetResponse.cs
@@ -7,6 +7,6 @@
 		public string OrderCode { get; set; } = string.Empty;
 		public List<OrderItemDto> OrderItems { get; set; } = new();
 		public decimal Total { get; set; }
-		public string OrderStatus { get; set; } = string.Empty;
+		public int OrderStatus { get; set; }
 	}
 }

--- a/src/core/ApplicationLayer/Requests/ProductDetailInfos/Queries/ProductDetailInfoGetRequest.cs
+++ b/src/core/ApplicationLayer/Requests/ProductDetailInfos/Queries/ProductDetailInfoGetRequest.cs
@@ -21,6 +21,7 @@
 			{
 				var productDetail = await _dbContext.ProductDetailInfos
 					.AsNoTracking()
+					.Include(i => i.ProductDetail)
 					.FirstOrDefaultAsync(x => x.Id == request.Id, cancellationToken);
 
 				if (productDetail is null)

--- a/src/core/ApplicationLayer/Requests/ProductDetailInfos/Queries/ProductDetailInfoGetResponse.cs
+++ b/src/core/ApplicationLayer/Requests/ProductDetailInfos/Queries/ProductDetailInfoGetResponse.cs
@@ -9,6 +9,7 @@
 		public int Id { get; set; }
 		public string DetailedDescription { get; set; } = string.Empty;
 		public string Parameters { get; set; } = string.Empty;
+		public string ProductCode { get; set; } = string.Empty;
 
 		public int Count { get; set; }
 
@@ -19,6 +20,7 @@
 				Id = v.Id,
 				DetailedDescription = v.DetailedDescription,
 				Parameters = v.Parameters,
+				ProductCode = v.ProductDetail.ProductCode
 			};
 		}
 	}

--- a/src/presentation/API/Constants/CookieNames.cs
+++ b/src/presentation/API/Constants/CookieNames.cs
@@ -1,0 +1,7 @@
+﻿namespace API.Constants
+{
+	public static class CookieNames
+	{
+		public const string ActualOrder = "ActualOrder";
+	}
+}

--- a/src/presentation/API/Controllers/BaseController.cs
+++ b/src/presentation/API/Controllers/BaseController.cs
@@ -19,6 +19,7 @@
 
 		public IMediator Mediator => _mediator;
 		public HateoasMaker HateoasMaker => _hateoasMaker;
+		public ILogger<T> Logger => _logger;
 
 		protected BaseController(IMediator mediator, ILogger<T> logger, HateoasMaker hateoasMaker) => (_mediator, _logger, _hateoasMaker) = (mediator, logger, hateoasMaker);
 
@@ -27,6 +28,13 @@
 			var accessToken = Request.Headers[HeaderNames.Authorization];
 			var token = new JwtSecurityTokenHandler().ReadJwtToken(accessToken.ToString().Replace("Bearer ", ""));
 			return Int32.Parse(token.Claims.First(c => c.Type == ClaimTypes.NameIdentifier).Value);
+		}
+
+		protected string? GetCookieValue(string name)
+		{
+			string? value;
+			Request.Cookies.TryGetValue(name, out value);
+			return value;
 		}
 	}
 }

--- a/src/presentation/API/Controllers/Orders/v1/OrdersController.cs
+++ b/src/presentation/API/Controllers/Orders/v1/OrdersController.cs
@@ -152,6 +152,7 @@
 					Path = "/",
 					Expires = DateTimeOffset.UtcNow.AddDays(1),
 					IsEssential = true,
+					HttpOnly = false,
 					Secure = true,
 				};
 
@@ -166,6 +167,7 @@
 				Path = "/",
 				Expires = DateTimeOffset.UtcNow.AddDays(1),
 				IsEssential = true,
+				HttpOnly = false,
 				Secure = true,
 			};
 

--- a/src/presentation/API/Controllers/Orders/v1/OrdersController.cs
+++ b/src/presentation/API/Controllers/Orders/v1/OrdersController.cs
@@ -152,7 +152,7 @@
 					Path = "/",
 					Expires = DateTimeOffset.UtcNow.AddDays(1),
 					IsEssential = true,
-					HttpOnly = false,
+					HttpOnly = true,
 					Secure = true,
 				};
 
@@ -167,7 +167,7 @@
 				Path = "/",
 				Expires = DateTimeOffset.UtcNow.AddDays(1),
 				IsEssential = true,
-				HttpOnly = false,
+				HttpOnly = true,
 				Secure = true,
 			};
 

--- a/src/presentation/API/Controllers/Orders/v1/OrdersController.cs
+++ b/src/presentation/API/Controllers/Orders/v1/OrdersController.cs
@@ -152,8 +152,7 @@
 					Path = "/",
 					Expires = DateTimeOffset.UtcNow.AddDays(1),
 					IsEssential = true,
-					HttpOnly = false,
-					Secure = false,
+					Secure = true,
 				};
 
 				Response.Cookies.Append(CookieNames.ActualOrder, actual.OrderCode, cookieOptions);
@@ -167,8 +166,7 @@
 				Path = "/",
 				Expires = DateTimeOffset.UtcNow.AddDays(1),
 				IsEssential = true,
-				HttpOnly = false,
-				Secure = false,
+				Secure = true,
 			};
 
 			Response.Cookies.Append(CookieNames.ActualOrder, result.OrderCode, cookieOptions);

--- a/src/presentation/API/Controllers/ProductDetails/v1/ProductDetailsController.cs
+++ b/src/presentation/API/Controllers/ProductDetails/v1/ProductDetailsController.cs
@@ -1,7 +1,6 @@
 ﻿namespace API.Controllers.ProductDetails.v1
 {
-	using API.Controllers.OrderItems.v1;
-	using API.Controllers.ProductDetailInfos.v1;
+	using API.Constants;
 	using ApplicationLayer.Requests.ProductDetails.Commands;
 	using ApplicationLayer.Requests.ProductDetails.Queries;
 	using ApplicationLayer.Requests.ProductDetails.Queries.Requests;
@@ -11,8 +10,11 @@
 	using Microsoft.AspNetCore.Authorization;
 	using Microsoft.AspNetCore.Mvc;
 	using Microsoft.Extensions.Logging;
+	using OrderItems.v1;
+	using ProductDetailInfos.v1;
 	using RadesSoft.HateoasMaker;
 	using RadesSoft.HateoasMaker.Attributes;
+	using RadesSoft.HateoasMaker.Extensions;
 
 	/// <summary>
 	/// Products endpoints v1
@@ -56,7 +58,18 @@
 					choices.Add(nameof(UpdateProductDetailAsync), "updateDescription");
 				}
 
-				result.Links.AddRange(HateoasMaker.GetByNames(choices, Url.ActionContext.HttpContext.GetRequestedApiVersion()?.MajorVersion ?? 1));
+				var links = HateoasMaker.GetByNames(choices, Url.ActionContext.HttpContext.GetRequestedApiVersion()?.MajorVersion ?? 1);
+
+				var cookieOrderCode = GetCookieValue(CookieNames.ActualOrder);
+
+				if (cookieOrderCode is not null)
+				{
+					links.First(x => x.ActionName == "onAddToCart").ReplaceInLink("{orderCode}", cookieOrderCode, "{productCode}", result.ProductCode);
+				}
+
+				links.First(x => x.ActionName == "productDetail").ReplaceInLink("{id}", result.Id.ToString());
+
+				result.Links = links;
 			});
 
 			return Ok(results);
@@ -83,7 +96,6 @@
 			var results = await Mediator.Send(new ProductDetailsGetPaginatedRequest() { OrderBy = p => p.Name, PageNumber = pageNum, PageSize = pageSize }, cancellationToken);
 			results.ToList().ForEach(result =>
 			{
-				//Add amount check here
 				var choices = new Dictionary<string, string?>
 				{
 					{ nameof(OrderItemsController.PutOrderItemAsync), "onAddToCart" },
@@ -95,7 +107,18 @@
 					choices.Add(nameof(UpdateProductDetailAsync), "updateDescription");
 				}
 
-				result.Links.AddRange(HateoasMaker.GetByNames(choices, Url.ActionContext.HttpContext.GetRequestedApiVersion()?.MajorVersion ?? 1));
+				var links = HateoasMaker.GetByNames(choices, Url.ActionContext.HttpContext.GetRequestedApiVersion()?.MajorVersion ?? 1);
+
+				var cookieOrderCode = GetCookieValue(CookieNames.ActualOrder);
+
+				if (cookieOrderCode is not null)
+				{
+					links.First(x => x.ActionName == "onAddToCart").ReplaceInLink("{orderCode}", cookieOrderCode, "{productCode}", result.ProductCode);
+				}
+
+				links.First(x => x.ActionName == "productDetail").ReplaceInLink("{id}", result.Id.ToString());
+
+				result.Links = links;
 			});
 			return Ok(results);
 		}
@@ -124,7 +147,17 @@
 				{ nameof(OrderItemsController.PutOrderItemAsync), "onAddToCart" },
 			};
 
-			result.Links.AddRange(HateoasMaker.GetByNames(choices, Url.ActionContext.HttpContext.GetRequestedApiVersion()?.MajorVersion ?? 1));
+			var links = HateoasMaker.GetByNames(choices, Url.ActionContext.HttpContext.GetRequestedApiVersion()?.MajorVersion ?? 1);
+			var cookieOrderCode = GetCookieValue(CookieNames.ActualOrder);
+
+			if (cookieOrderCode is not null)
+			{
+				links.First(x => x.ActionName == "onAddToCart").ReplaceInLink("{orderCode}", cookieOrderCode, "{productCode}", result.ProductCode);
+			}
+
+			links.First(x => x.ActionName == "self").ReplaceInLink("{id}", result.Id.ToString());
+
+			result.Links = links;
 
 			return Ok(result);
 		}

--- a/src/presentation/API/Controllers/Users/v1/UsersController.cs
+++ b/src/presentation/API/Controllers/Users/v1/UsersController.cs
@@ -58,7 +58,6 @@
 					{ nameof(OrdersController.GetOrdersFilteredAsync), "onCartClick" },
 					{ nameof(ProductDetailsController.GetProductDetailsPaginatedAsync), "loadProductCards" },
 					{ nameof(ProductDetailsController.GetProductDetailByIdAsync), "onProductClick" },
-					{ nameof(OrderItemsController.PutOrderItemAsync), "onAddToCart" },
 				}, Url.ActionContext.HttpContext.GetRequestedApiVersion()?.MajorVersion ?? 1);
 
 			return Ok(result);


### PR DESCRIPTION
**Work performed**
Added functionality to add order number to cookies when endpoint with orders is called
this cookie is used for generating HATEOAS responses

**Tests performed**
Called endpoints with cookie value in response
![image](https://user-images.githubusercontent.com/37796889/180842323-2960e178-1a1d-49ce-a647-583f30389b9e.png)
works fine

fixes #96 